### PR TITLE
Update installation instructions for GEOQuery - replace expired URL

### DIFF
--- a/Rmd/GEOquery.Rmd
+++ b/Rmd/GEOquery.Rmd
@@ -17,8 +17,10 @@ library(GEOquery)
 Use the following commands to install these packages in R.
 
 ```{r biocLite, eval=FALSE}
-source("http://www.bioconductor.org/biocLite.R")
-biocLite(c("GEOquery"))
+if (!require("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+
+BiocManager::install("GEOquery")
 ```
 
 ## Overview

--- a/html/GEOquery.html
+++ b/html/GEOquery.html
@@ -71,8 +71,10 @@ document.addEventListener("DOMContentLoaded", function() {
 <p>This document has the following dependencies:</p>
 <pre class="r"><code>library(GEOquery)</code></pre>
 <p>Use the following commands to install these packages in R.</p>
-<pre class="r"><code>source(&quot;http://www.bioconductor.org/biocLite.R&quot;)
-biocLite(c(&quot;GEOquery&quot;))</code></pre>
+<pre class="r"><code>if (!require("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+
+BiocManager::install("GEOquery")</code></pre>
 </div>
 <div id="overview" class="section level2">
 <h2>Overview</h2>

--- a/html/GEOquery.html
+++ b/html/GEOquery.html
@@ -71,10 +71,10 @@ document.addEventListener("DOMContentLoaded", function() {
 <p>This document has the following dependencies:</p>
 <pre class="r"><code>library(GEOquery)</code></pre>
 <p>Use the following commands to install these packages in R.</p>
-<pre class="r"><code>if (!require("BiocManager", quietly = TRUE))
-    install.packages("BiocManager")
+<pre class="r"><code>if (!require(&quot;BiocManager&quot;, quietly = TRUE))
+    install.packages(&quot;BiocManager&quot;)
 
-BiocManager::install("GEOquery")</code></pre>
+BiocManager::install(&quot;GEOquery&quot;)</code></pre>
 </div>
 <div id="overview" class="section level2">
 <h2>Overview</h2>


### PR DESCRIPTION
Previous installation instructions contained an expired URL:

```
cannot open URL 'https://www.bioconductor.org/biocLite.R': HTTP status was '404 Not Found'
```

I updated the instructions according to the following page: 
https://www.bioconductor.org/packages/release/bioc/html/GEOquery.html

------

P.S .In addition, the code contains multiple references to the expired URL in the comments. If needed, I can update it as well.